### PR TITLE
Fix class name mismatch in rep-check-in-command.ts

### DIFF
--- a/commands/rep-check-in-command.ts
+++ b/commands/rep-check-in-command.ts
@@ -36,7 +36,7 @@ import { TransactionCommand, TransactionEvent, CommandContext } from '../core/ty
  * (MatchStoreToProductCommand). This is an example of the Event-Driven Architecture
  * pattern, where commands produce events that trigger other commands.
  */
-export class RepCheckIn implements TransactionCommand {
+export class AssignRepCommand implements TransactionCommand {
   /** Unique identifier for this command instance */
   commandId = 'rep-check-in-' + Math.random().toString(36).substring(2, 9);
   


### PR DESCRIPTION
## Fix class name mismatch in rep-check-in-command.ts

This PR fixes the class name mismatch between the exported class in `rep-check-in-command.ts` and how it's imported in `index.ts`.

### Changes
- Renamed the class in `rep-check-in-command.ts` from `RepCheckIn` to `AssignRepCommand` to match the import in `index.ts`

### Testing
- Verified that the application now runs successfully with `npm start`
- All functionality works as expected

Fixes #1